### PR TITLE
specify the diff command to be used by svn: the internal-diff command.

### DIFF
--- a/latexdiff-1.1.0/latexdiff-vc
+++ b/latexdiff-1.1.0/latexdiff-vc
@@ -192,7 +192,7 @@ if ( scalar(@revs)>0 ) {
     $diffcmd  = "rcsdiff -u -r";  
     $patchcmd = "patch -R -p0";
   } elsif ( $vc eq "SVN" ) {
-    $diffcmd  = "svn diff -r ";  
+    $diffcmd  = "svn diff --internal-diff -r ";  
     $patchcmd = "patch -R -p0";
   } elsif ( $vc eq "GIT" ) {
     $diffcmd  = "git diff -r --relative --no-prefix ";  


### PR DESCRIPTION
Hello,

Thanks for the latexdiff utilities!

I propose the following patch in order to make it possible to overwrite the 
svn diff command as defined in the svn configuration file.
Indeed, if a visual diff tool such as meld is used in the svn configuration file,
the output of such diff commands may not be further usable by
latexdiff
