### PR TITLE
restore \item, even if there is an unsafe command after the item

### DIFF
--- a/latexdiff
+++ b/latexdiff
@@ -2819,7 +2819,7 @@ sub postprocess {
 sub restore_item_commands {
   my ($string)=@_ ;
   my ($itemarg,@itemargs);
-  $string =~ s/(\%DIFDELCMD < \s*(\\$ITEMCMD)((?:<$abrat0>)?)((?:\[$brat0\])?)\s*?(?:\n|$DELCMDCLOSE))/
+  $string =~ s/(\%DIFDELCMD < \s*(\\$ITEMCMD)((?:<$abrat0>)?)((?:\[$brat0\])?)\s*((?:$cmdoptseq)?)\s*?(?:\n|$DELCMDCLOSE))/
      # if \item has an []argument, then mark up the argument as deleted)
      if (length($4)>0) {
        # use substr to exclude square brackets at end points
@@ -2828,7 +2828,8 @@ sub restore_item_commands {
      } else {
        $itemarg="";
      }
-     "$1$2$3$itemarg$AUXCMD\n"/sge;
+     "$2$3$itemarg$AUXCMD\n".((length($5)>0) ? "%DIFDELCMD $5 $DELCMDCLOSE\n" : "")
+     /sge;
   return($string);
 }
 


### PR DESCRIPTION
Handling items breaks if the \item is followed by a command. For removing this code:
```
\begin{itemize}
\item \verb{my_id_t} for reference see \myref{sec:my_id_t}.
\end{itemize}
```
The result was:
```
%DIFDELCMD < \begin{itemize}
\begin{itemize}%DIFAUXCMD
%DIFDELCMD < \item \verb{my_id_t} %%%
\DIFdel{type, see
}%DIFDELCMD < \myref{sec:my_id_t}%%%
\DIFdel{.
}
\end{itemize}%DIFAUXCMD
%DIFDELCMD < \end{itemize}
```

Probably, this is not only a problem for commands? Should we check for more than just `$cmdoptseq`?