### PR TITLE
fix error "Negative repeat count does nothing at..."

### DIFF
--- a/latexdiff
+++ b/latexdiff
@@ -731,18 +731,30 @@ if ( ! -e $newfile ) {
 
 
 # set the labels to be included into the file
+# first find out which file name is longer for correct alignment
+my ($diff,$oldlabel_n_spaces,$newlabel_n_spaces);
+$oldlabel_n_spaces = 0;
+$newlabel_n_spaces = 0;
+$diff = length($newfile) - length($oldfile);
+if ($diff > 0) {
+  $oldlabel_n_spaces = $diff;
+}
+if ($diff < 0) {
+  $newlabel_n_spaces = abs($diff);
+}
+
 my ($oldtime,$newtime,$oldlabel,$newlabel);
 if (defined($labels[0])) {
   $oldlabel=$labels[0] ;
 } else {
   $oldtime=localtime((stat($oldfile))[9]); 
-  $oldlabel="$oldfile   " . " "x(length($newfile)-length($oldfile)) . $oldtime;
+  $oldlabel="$oldfile   " . " "x($oldlabel_n_spaces) . $oldtime;
 }
 if (defined($labels[1])) {
   $newlabel=$labels[1] ;
 } else {
   $newtime=localtime((stat($newfile))[9]);
-  $newlabel="$newfile   " . " "x(length($oldfile)-length($newfile)) . $newtime;
+  $newlabel="$newfile   " . " "x($newlabel_n_spaces) . $newtime;
 }
 
 $encoding=guess_encoding($newfile) unless defined($encoding);


### PR DESCRIPTION
Hi ftilmann. I had a problem with latexdiff when updating my arch system. I found a post on the arch forum (https://bbs.archlinux.org/post.php?tid=226993), but the solution did not work for me. So I tried to fix it on my own. Luckily, it was a trivial problem (I have exactly 0 experience with perl).

A negative number is given to the repeat operator "x" when adding spaces for proper alignment of the labels (file names). I guess with an older perl version a negative number was just not evaluated? 

I did not really check for any style guides and I guess you might have chosen other variable names (I can change this, if you request it). Anyway, I just needed a working latexdiff quickly and wanted to share my solution (if this deserves the name).