### PR TITLE
Solving issue #108 opened on Jul 2

### DIFF
--- a/latexdiff
+++ b/latexdiff
@@ -1496,8 +1496,8 @@ sub flatten {
 	    $begline=(defined($1)? $1 : "") ;
 	    $fname = $2 if defined($2) ;
 	    $fname = $3 if defined($3) ;
-            #      # add tex extension unless there is a three letter extension already 
-            $fname .= ".tex" unless $fname =~ m|\.\w{3}$|;
+            #      # add tex extension unless there is a three or four letter extension already 
+            $fname .= ".tex" unless $fname =~ m|\.\w{3,4}$|;
             print STDERR "DEBUG Beg of line match |$1|\n" if defined($1) && $debug ;
             print STDERR "Include file $fname\n" if $verbose;
             print STDERR "DEBUG looking for file ",File::Spec->catfile($dirname,$fname), "\n" if $debug;
@@ -1525,8 +1525,8 @@ sub flatten {
   $text=~s/(^(?:[^%\n]|\\%)*)\\subfile\{(.*?)\}/{ 
            $begline=(defined($1)? $1 : "") ;
      	   $fname = $2; 
-           #      # add tex extension unless there is a three letter extension already 
-           $fname .= ".tex" unless $fname =~ m|\.\w{3}|;
+           #      # add tex extension unless there is a three or four letter extension already 
+           $fname .= ".tex" unless $fname =~ m|\.\w{3,4}|;
 ###           print STDERR "DEBUG Beg of line match |$1|\n" if defined($1) && $debug ;
            print STDERR "Include file as subfile $fname\n" if $verbose;
 ###           print STDERR "DEBUG looking for file ",File::Spec->catfile($dirname,$fname), "\n" if $debug;


### PR DESCRIPTION
Consider extensions with 4 letters as also valid when expanding input, include and subfile commands