### PR TITLE
Perl is complaining about an unescaped left bracket

### DIFF
--- a/latexdiff
+++ b/latexdiff
@@ -695,7 +695,7 @@ push(@SAFECMDLIST, qr/^QLEFTBRACE$/, qr/^QRIGHTBRACE$/);
   my $pat_n = $pat0;
 # if you get "undefined control sequence MATHBLOCKmath" error, increase the maximum value in this loop
   for (my $i_pat = 0; $i_pat < 20; ++$i_pat){
-    $pat_n = '(?:[^{}]|\{'.$pat_n.'\}|\\\{|\\\})*';
+    $pat_n = '(?:[^{}]|\{'.$pat_n.'\}|\\\\\{|\\\\\})*';
     ###  $pat_n = '(?:[^{}]|\{'.$pat_n.'\})*';
   }
 


### PR DESCRIPTION
An alternative expression might be (but would actually capture the nested brackets, so ?1 would need to be adopted on use):
(\{(?:(?1)|[^{}]*+)++\})

I'm using perl 5.24.1 and get multiple of warnings on execution.