### PR TITLE
Invoked latexdiff ignores the config argument without the equal sign

### DIFF
--- a/latexdiff-vc
+++ b/latexdiff-vc
@@ -328,7 +328,7 @@ while( $file1=pop @ARGV ) {
 }
 
 if ( length $configlatexdiff >0 ) {
-  push @ldoptions, "--config $configlatexdiff";
+  push @ldoptions, "--config=$configlatexdiff";
 }
 
 if ( defined($flatten) ) {


### PR DESCRIPTION
config is not propagated properly from latexdiff-vc to the invoked latexdiff command

With this fix, also the final latexdiff has the config