### PR TITLE
Add config option to provide names for lstinline-like commands

### DIFF
--- a/latexdiff
+++ b/latexdiff
@@ -2426,9 +2426,9 @@ sub preprocess {
 
     # Mark inline-verb in commented lines to be COMMENTverb (no hashing, no marking with color)
     1 while s/((?<!\\)%.*)\\(verb\*?|$LSTINLINEENV)/$1\\COMMENT$2/mg;
-    s/\\($LSTINLINEENV)((?:\[$brat_n\])?)(\{(?:.*?)\})/"\\DIF${1}". $2 ."{". tohash(\%verbhash,"$3") ."}"/esg;
-    s/\\($LSTINLINEENV)((?:\[$brat_n\])?)(([^\s\w]).*?\3)/"\\DIF${1}". $2 ."{". tohash(\%verbhash,"$3") ."}"/esg;
-    s/\\(verb\*?|$LSTINLINEENV)([^\s\w])(.*?)\2/"\\DIF${1}{". tohash(\%verbhash,"${2}${3}${2}") ."}"/esg;
+    s/\\($LSTINLINEENV)((?:\[$brat_n\])?)(\{(?:.*?)\})/"\\DIF${1}". $2 ."{". tohash(\%verbhash,"$3") ."}"/eg;
+    s/\\($LSTINLINEENV)((?:\[$brat_n\])?)(([^\s\w]).*?\3)/"\\DIF${1}". $2 ."{". tohash(\%verbhash,"$3") ."}"/eg;
+    s/\\(verb\*?|$LSTINLINEENV)([^\s\w])(.*?)\2/"\\DIF${1}{". tohash(\%verbhash,"${2}${3}${2}") ."}"/eg;
 
     #    Change \{ to \QLEFTBRACE, \} to \QRIGHTBRACE, and \& to \AMPERSAND
 ###    print STDERR "Preprocess 0\n" if $debug;
@@ -3088,12 +3088,12 @@ sub postprocess {
       # if there is a comment, that we did not catch with COMMENTverb, just ignore the diff
       1 while s/(\%.*)\\DIFDIF(?:add|del)(verb\*?|$LSTINLINEENV)/$1\\DIF$2/mg;
       # wrap added verb commands with color commands
-      s/\\DIFDIFadd((?:verb\*?|$LSTINLINEENV(?:\[$brat_n\])?)\{[-\d]*?\}[\s\n]*)/\{\\color{blue}$AUXCMD\n\\DIF$1%\n\}$AUXCMD\n/sg;
-      s/\\DIFDIFdel((?:verb\*?|$LSTINLINEENV(?:\[$brat_n\])?)\{[-\d]*?\}[\s\n]*$AUXCMD)/\{\\color{red}${AUXCMD}\n\\DIF$1\n\}${AUXCMD}/sg;
+      s/\\DIFDIFadd((?:verb\*?|$LSTINLINEENV(?:\[$brat_n\])?)\{[-\d]*?\}[\s\n]*)/\{\\color{blue}$AUXCMD\n\\DIF$1%\n\}$AUXCMD\n/g;
+      s/\\DIFDIFdel((?:verb\*?|$LSTINLINEENV(?:\[$brat_n\])?)\{[-\d]*?\}[\s\n]*$AUXCMD)/\{\\color{red}${AUXCMD}\n\\DIF$1\n\}${AUXCMD}/g;
     } else {
       # currently if colour markup is not used just remove the added mark
-      s/\\DIFDIFadd(verb\*?|$LSTINLINEENV)/\\DIF$1/sg;
-      s/\\DIFDIFdel((?:verb\*?|$LSTINLINEENV(?:\[$brat_n\])?)\{[-\d]*?\}[\s\n]*$AUXCMD\n)//sg;
+      s/\\DIFDIFadd(verb\*?|$LSTINLINEENV)/\\DIF$1/g;
+      s/\\DIFDIFdel((?:verb\*?|$LSTINLINEENV(?:\[$brat_n\])?)\{[-\d]*?\}[\s\n]*$AUXCMD\n)//g;
     }
     # expand \verb and friends inline arguments
 #    1 while s/\\DIF((?:DIFadd|DIFdel)?(?:verb\*?|$LSTINLINEENV(?:\[$brat_n\])?))\{([-\d]*?)\}/"\\${1}". fromhash(\%verbhash,$2)/meg;

--- a/latexdiff
+++ b/latexdiff
@@ -206,6 +206,7 @@ my %CONFIG=(
    LISTENV => undef ,  # list making environments - they will generally be kept
    VERBATIMENV => undef,      # Environments whose content should be treated as verbatim text and not be touched
    VERBATIMLINEENV => undef,  # Environments whose content should be treated as verbatim text and processed in line diff mode
+   LSTINLINEENV => undef,# Environments whose content should be treated as lstinline text and processed as lstinline
    ITEMCMD => 'item'                    # command marking item in a list environment
 );
 # Configuration variables: these have to be visible from the subroutines
@@ -222,7 +223,8 @@ my ($ARRENV,
     $PICTUREENV,
     $SCALEDELGRAPHICS,
     $VERBATIMENV,
-    $VERBATIMLINEENV
+    $VERBATIMLINEENV,
+    $LSTINLINEENV
     );
 
 # my $MINWORDSBLOCK=3; # minimum number of tokens to form an independent block
@@ -623,6 +625,7 @@ foreach  ( keys(%CONFIG) ) {
   elsif ( $_ eq "ARRENV" ) { $ARRENV = liststringtoregex($CONFIG{$_}) ; }
   elsif ( $_ eq "VERBATIMENV" ) { $VERBATIMENV = liststringtoregex($CONFIG{$_}) ; }
   elsif ( $_ eq "VERBATIMLINEENV" ) { $VERBATIMLINEENV = liststringtoregex($CONFIG{$_}) ; }
+  elsif ( $_ eq "LSTINLINEENV" ) { $LSTINLINEENV = liststringtoregex($CONFIG{$_}) ; }
   elsif ( $_ eq "COUNTERCMD" ) { $COUNTERCMD = liststringtoregex($CONFIG{$_}) ; }
   elsif ( $_ eq "SCALEDELGRAPHICS" ) { $SCALEDELGRAPHICS = $CONFIG{$_} ; }
   else { die "Unknown configuration variable $_.";}
@@ -1302,6 +1305,7 @@ sub show_configuration {
     print "SCALEDELGRAPHICS=$SCALEDELGRAPHICS\n";
     print "VERBATIMENV=$VERBATIMENV\n";
     print "VERBATIMLINEENV=$VERBATIMLINEENV\n";
+    print "LSTINLINEENV=$LSTINLINEENV\n";
   }
 }
 
@@ -2419,9 +2423,12 @@ sub preprocess {
     # transform \lstinline{...}
 #    s/\\lstinline(\[$brat0\])?(\{(?:.*?)\})/"\\DIFlstinline". $1 ."{". tohash(\%verbhash,"$2") ."}"/esg;
 #    s/\\lstinline(\[$brat0\])?((\S).*?\2)/"\\DIFlstinline". $1 ."{". tohash(\%verbhash,"$2") ."}"/esg;
-    s/\\lstinline((?:\[$brat_n\])?)(\{(?:.*?)\})/"\\DIFlstinline". $1 ."{". tohash(\%verbhash,"$2") ."}"/esg;
-    s/\\lstinline((?:\[$brat_n\])?)(([^\s\w]).*?\3)/"\\DIFlstinline". $1 ."{". tohash(\%verbhash,"$2") ."}"/esg;
-    s/\\(verb\*?|lstinline)([^\s\w])(.*?)\2/"\\DIF${1}{". tohash(\%verbhash,"${2}${3}${2}") ."}"/esg;
+
+    # Mark inline-verb in commented lines to be COMMENTverb (no hashing, no marking with color)
+    1 while s/((?<!\\)%.*)\\(verb\*?|$LSTINLINEENV)/$1\\COMMENT$2/mg;
+    s/\\($LSTINLINEENV)((?:\[$brat_n\])?)(\{(?:.*?)\})/"\\DIF${1}". $2 ."{". tohash(\%verbhash,"$3") ."}"/esg;
+    s/\\($LSTINLINEENV)((?:\[$brat_n\])?)(([^\s\w]).*?\3)/"\\DIF${1}". $2 ."{". tohash(\%verbhash,"$3") ."}"/esg;
+    s/\\(verb\*?|$LSTINLINEENV)([^\s\w])(.*?)\2/"\\DIF${1}{". tohash(\%verbhash,"${2}${3}${2}") ."}"/esg;
 
     #    Change \{ to \QLEFTBRACE, \} to \QRIGHTBRACE, and \& to \AMPERSAND
 ###    print STDERR "Preprocess 0\n" if $debug;
@@ -2812,7 +2819,7 @@ sub postprocess {
       ###  $delblock =~ s/\\DIFlstinline/\\DIFDIFdellstinline/g;
       ###}
       # Mark deleted verbose commands
-      $delblock =~ s/(${DELCMDOPEN}\\DIF((?:verb\*?|lstinline(?:\[$brat_n\])?)\{([-\d]*?)\}\s*).*)$/%\n\\DIFDIFdel$2${AUXCMD}\n$1/gm;
+      $delblock =~ s/(${DELCMDOPEN}\\DIF((?:verb\*?|$LSTINLINEENV(?:\[$brat_n\])?)\{([-\d]*?)\}\s*).*)$/%\n\\DIFDIFdel$2${AUXCMD}\n$1/gm;
 
 #     splice in modified delblock
       substr($_,$begin,$len)=$delblock;
@@ -2855,7 +2862,8 @@ sub postprocess {
       ###if ( defined($packages{"listings"} and $latexdiffpreamble =~ /\\RequirePackage(?:\[$brat0\])?\{color\}/))   { 
 	# mark added verbatim commands
       $addblock =~ s/\\DIFverb/\\DIFDIFaddverb/g;
-      $addblock =~ s/\\DIFlstinline/\\DIFDIFaddlstinline/g;
+      1 while $addblock =~ s/((?<!\\)%.*)\\DIF($LSTINLINEENV)/$1\\DIFDIFadd$2/mg;
+      $addblock =~ s/\\DIF($LSTINLINEENV)/\\DIFDIFadd$1/g;
       ###}
 #     splice in modified addblock
       substr($_,$begin,$len)=$addblock;
@@ -2991,7 +2999,7 @@ sub postprocess {
           (\Q$DELCMDOPEN\E\\begin\{($VERBATIMLINEENV)\}(\Q$extraspace\E(?:\[$brat_n\])?\s*)(?:\n|\Q$DELCMDOPEN\E)*\Q$DELCMDCLOSE\E)
         # Interior of deleted verbatim environment should consist entirely of delete DIFVRB comments, i.e. match only lines beginning with % DIF < DIFVRB
         #   Captures: $4: all lines combined
-          ((?:\%\Q$DELCOMMENT$VERBCOMMENT\E.*?\n)*)
+          ((?:\%\Q$DELCOMMENT$VERBCOMMENT\E[^\n]*?\n)*)
         # Deleted \end command of verbatim environment. Note that the type is forced to match the opening. Captures: $5: Whole deleted environment
           (\Q$DELCMDOPEN\E\\end\{\2\}(?:\n|\s|\Q$DELCMDOPEN\E)*\Q$DELCMDCLOSE\E)
       / # Substitution part 
@@ -3068,6 +3076,8 @@ sub postprocess {
     1 while s/(%.*)\\CRIGHTBRACE (.*)$/$1\}$2/mg ;
     1 while s/(%.*)\\CLEFTBRACE (.*)$/$1\{$2/mg ;
 
+    # Patch back inline-verb in comments
+    s/\\COMMENT(verb\*?|$LSTINLINEENV)/\\$1/mg ;
 
 #    Change \QLEFTBRACE, \QRIGHTBRACE to \{,\}
     s/\\QLEFTBRACE /\\\{/sg;
@@ -3075,16 +3085,20 @@ sub postprocess {
     s/\\AMPERSAND /\\&/sg;
     # Highligh added inline verbatim commands if possible
     if ( $latexdiffpreamble =~ /\\RequirePackage(?:\[$brat_n\])?\{color\}/ )   { 
+      # if there is a comment, that we did not catch with COMMENTverb, just ignore the diff
+      1 while s/(\%.*)\\DIFDIF(?:add|del)(verb\*?|$LSTINLINEENV)/$1\\DIF$2/mg;
       # wrap added verb commands with color commands
-      s/\\DIFDIFadd((?:verb\*?|lstinline(?:\[$brat_n\])?)\{[-\d]*?\}[\s\n]*)/\{\\color{blue}$AUXCMD\n\\DIF$1%\n\}$AUXCMD\n/sg;
-      s/\\DIFDIFdel((?:verb\*?|lstinline(?:\[$brat_n\])?)\{[-\d]*?\}[\s\n]*$AUXCMD)/\{\\color{red}${AUXCMD}\n\\DIF$1\n\}${AUXCMD}/sg;
+      s/\\DIFDIFadd((?:verb\*?|$LSTINLINEENV(?:\[$brat_n\])?)\{[-\d]*?\}[\s\n]*)/\{\\color{blue}$AUXCMD\n\\DIF$1%\n\}$AUXCMD\n/sg;
+      s/\\DIFDIFdel((?:verb\*?|$LSTINLINEENV(?:\[$brat_n\])?)\{[-\d]*?\}[\s\n]*$AUXCMD)/\{\\color{red}${AUXCMD}\n\\DIF$1\n\}${AUXCMD}/sg;
     } else {
       # currently if colour markup is not used just remove the added mark
-      s/\\DIFDIFadd(verb\*?|lstinline)/\\DIF$1/sg;
-      s/\\DIFDIFdel((?:verb\*?|lstinline(?:\[$brat_n\])?)\{[-\d]*?\}[\s\n]*$AUXCMD\n)//sg;
+      s/\\DIFDIFadd(verb\*?|$LSTINLINEENV)/\\DIF$1/sg;
+      s/\\DIFDIFdel((?:verb\*?|$LSTINLINEENV(?:\[$brat_n\])?)\{[-\d]*?\}[\s\n]*$AUXCMD\n)//sg;
     }
     # expand \verb and friends inline arguments
-    s/\\DIF((?:DIFadd|DIFdel)?(?:verb\*?|lstinline(?:\[$brat_n\])?))\{([-\d]*?)\}/"\\${1}". fromhash(\%verbhash,$2)/esg;
+#    1 while s/\\DIF((?:DIFadd|DIFdel)?(?:verb\*?|$LSTINLINEENV(?:\[$brat_n\])?))\{([-\d]*?)\}/"\\${1}". fromhash(\%verbhash,$2)/meg;
+    # make sure to unpack nested inline-verb ;)
+    1 while s/\\DIF((?:DIFadd|DIFdel)?(?:verb\*?|$LSTINLINEENV(?:\[$brat_n\])?))\{([-\d]*?)\}/"\\${1}". fromhash(\%verbhash,$2)/meg;
     # add basicstyle color{blue} to added lstinline commands
     # finally add the comment to the ones not having an optional argument before
     ###s/\\DIFaddlstinline(?!\[)/\\lstinline\n[basicstyle=\\color{blue}]$AUXCMD\n/g;
@@ -3530,6 +3544,7 @@ be real files (not pipes or similar) as they are opened twice.
                           SCALEDELGRAPHICS (Float)
                           VERBATIMENV (RegEx)
                           VERBATIMLINEENV (RegEx)
+                          LSTINLINEENV (RegEx)
                        This option can be repeated.
 
 --add-to-config  varenv1=pattern1,varenv2=pattern2
@@ -4839,6 +4854,10 @@ comment
 lstlisting
 verbatim[*]?
 %%END VERBATIMLINEENV CONFIG
+
+%%BEGIN LSTINLINEENV CONFIG
+lstinline
+%%END LSTINLINEENV CONFIG
 
 %%% TYPES (Commands for highlighting changed blocks)
 


### PR DESCRIPTION
This PR adds the possibility to configure customized lstinline-like commands/shortcuts.
For something like:
`\newcommand\myJSsnippet{\lstinline[style=JavaScript,breaklines=true]}
`
You would add this to the config:
`LSTINLINEENV=myJSsnippet
`
