### PR TITLE
latexdiff-vc: generate .bbl files before calling latexdiff

### DIFF
--- a/latexdiff-vc
+++ b/latexdiff-vc
@@ -404,7 +404,8 @@ while ( $infile=$file2=shift @files ) {
   print STDERR "Working on  $infile \n";
   if ( scalar(@revs) == 1 ) {
     if ( defined($flatten) ) {
-       my $olddir=$tempdir . "/latexdiff-vc-$revs[0]";
+       (my $revs0 = $revs[0]) =~ s/[^\w]/-/g; # needed so that latex doesn't get stuck with ~ et al
+       my $olddir=$tempdir . "/latexdiff-vc-$revs0";
        print STDERR "Checking out old dir into: $olddir (rev: $revs[0])\n";
        checkout_dir($revs[0],$olddir);
 ###       print STDERR "DEBUG olddir $olddir";
@@ -424,12 +425,14 @@ while ( $infile=$file2=shift @files ) {
      }
   } elsif ( scalar(@revs) == 2 ) {
     if ( defined($flatten) ) {
-      my $olddir=$tempdir . "/latexdiff-vc-$revs[0]";
+      (my $revs0 = $revs[0]) =~ s/[^\w]/-/g; # needed so that latex doesn't get stuck with ~ et al
+      my $olddir=$tempdir . "/latexdiff-vc-$revs0";
       print STDERR "Checking out old dir into: $olddir (rev: $revs[0])\n";
       checkout_dir($revs[0],$olddir);
       $file1=$olddir ."/".$infile;
 
-      my $newdir=$tempdir . "/latexdiff-vc-$revs[1]";
+      (my $revs1 = $revs[1]) =~ s/[^\w]/-/g; # needed so that latex doesn't get stuck with ~ et al
+      my $newdir=$tempdir . "/latexdiff-vc-$revs1";
       print STDERR "Checking out new dir into: $newdir\n";
       checkout_dir($revs[1],$newdir);
       $file2=$newdir ."/".$infile;
@@ -477,6 +480,20 @@ while ( $infile=$file2=shift @files ) {
     unless ($answer =~ /^y/i ) {
       unlink @tmpfiles;
       die "Abort ... " ;
+    }
+  }
+  if (1) { # !TODO! Replace with a suited check (or remove check)
+    if ( system("grep -q \'^[^%]*\\\\bibliography{\' \"$file1\"") == 0 ) {
+      print "DEBUG: Running bibtex on $file1\n" if $debug;
+      (my $file1base = $file1) =~ s/\.tex$//i;
+      my $file1path = dirname $file1;
+      system("cd '$file1path'; $CFG{LATEX} --interaction=batchmode '$file1'; $CFG{BIBTEX} '$file1base'");
+    }
+    if ( system("grep -q \'^[^%]*\\\\bibliography{\' \"$file2\"") == 0 ) {
+      print "DEBUG: Running bibtex on $file2\n" if $debug;
+      (my $file2base = $file2) =~ s/\.tex$//i;
+      my $file2path = dirname $file2;
+      system("cd '$file2path'; $CFG{LATEX} --interaction=batchmode '$file2'; $CFG{BIBTEX} '$file2base'");
     }
   }
   print STDERR "Running: $CFG{LATEXDIFF}  $options \"$file1\" \"$file2\" > \"$diff\"\n";


### PR DESCRIPTION
My git project does not track the `.bbl` files, which made sense at the time of creating it since those files are a product, not a source.  As a result, `latexdiff-vc` fails to generate the bibliography and all references appear as [**??**].

This patch is a quick and ugly hack I made into the `latexdiff-vc` code (as downloaded from CTAN, which seems to be slightly different from the one here on github) that calls `bibtex` into `$file1` and `$file2` in order to generate the `.bbl` files before calling `latexdiff`.  However **it will probably need some work before being ready to be merged:**
* The code should probably check some conditions (such as `$flatten` and/or `$run`) before calling `bibtex`, but I was not sure what would be the way to go.  Or maybe the whole block should be moved inside the `if ( defined($flatten) )` parts where `$olddir` and `$newdir` are declared.
* Maybe `[pdf]latex` should be called with `-draftmode` in order to improve the speed (then again, maybe this should be done on ALL calls to `$CFG{LATEX}` except the last one), but I don't know if this option is `latex`-specific and thus unsupported by other LaTeX compilers (then again, this is probably no different for `--interactive=batchmode` as well).
* The documentation should be changed accordingly.
* I included `cd '$fileNpath';` in the latex-and-bibtex call I added because otherwise LaTeX complained about relative '\input's; not sure if this was the most elegant way to go but it Just Works™.
* I modified the way `$olddir` and `$newdir` are generated, because I was having trouble when calling `pdflatex` on `/tmp/me7swkOS1w/latexdiff-vc-HEAD~1/tex/main.tex` because of the damned `~`.  On second thought, maybe having done `cd` to that directory first and then calling the latex and bibtex commands without the path would have been a better option.  (I hope nobody uses this for comparing commits `HEAD~2` and `HEAD^2` for example... maybe this wasn't such a good idea after all.)

Please do not consider this as a ready-to-use PR but rather as a suggestion for improvement; as I said it was an ugly hack which will likely need some work and reviewing before being ready (in fact my original idea was to report this as a regular issue, but the patch seemed more convenient).  Feel free to ditch the whole PR if you like the idea but prefer to rewrite it from scratch :)

I tested the program with my particular use case and it worked, but I didn't perform extensive testing (I did this in a couple of hours; I just learned about this software today... by the way, kudos to the creators!)