### PR TITLE
Fix issue for removing larger parts of a document

### DIFF
--- a/latexdiff
+++ b/latexdiff
@@ -3021,7 +3021,7 @@ sub postprocess {
         #   Captures: $4: all lines combined
           ((?:\%\Q$DELCOMMENT$VERBCOMMENT\E[^\n]*?\n)*)
         # Deleted \end command of verbatim environment. Note that the type is forced to match the opening. Captures: $5: Whole deleted environment
-          (\Q$DELCMDOPEN\E\\end\{\2\}(?:\n|\s|\Q$DELCMDOPEN\E)*\Q$DELCMDCLOSE\E)
+          (\Q$DELCMDOPEN\E\\end\{\2\})
       / # Substitution part 
             $1                   # Leave expression as is 
             . "$AUXCMD NEXT\n"   # Mark the following line as an auxiliary command


### PR DESCRIPTION
If there are more changes after the deleted verbatim block, this pattern
did not match and the removed verbatim did not show up in the diff.
Finding the `\end{verbatim}` should be sufficient. 

Removing the figure from this MWE would result in an empty section. With this patch, the removed code is shown:
```
\documentclass{book}
\begin{document}
\chapter{chapter1}
\begin{figure}
\begin{verbatim}
int main(int argc, char** argv){return 0;}
\end{verbatim}
\end{figure}
\end{document}
```