### PR TITLE
fix POD syntax error

### DIFF
--- a/latexdiff
+++ b/latexdiff
@@ -4269,9 +4269,9 @@ Show version number
 
 =head2 Internal options
 
-=over 4
-
 These options are mostly for automated use by latexdiff-vc. They can be used directly, but the API should be considered less stable than for the other options.
+
+=over 4
 
 =item B<--no-links>
 


### PR DESCRIPTION
running pod2man -center=" " latexdiff > dist/latexdiff.1

(as done during 'make distribution')
found a syntax error:

latexdiff around line 4272: You can't have =items (as at line 4276) unless the first thing after the =over is an =item
POD document had syntax errors at /usr/bin/pod2man line 71.