### PR TITLE
Fix issue #180 (--flatten fails on Windows)

### DIFF
--- a/latexdiff-vc
+++ b/latexdiff-vc
@@ -473,7 +473,7 @@ while ( $infile=$file2=shift @files ) {
 
   # Remaining options are passed to latexdiff
   if (scalar(@ldoptions) > 0 ) {
-    $options = "\'" . join("\' \'",@ldoptions) . "\'";
+    $options = join(" ",@ldoptions);
   } else {
     $options = "";
   }
@@ -613,7 +613,7 @@ sub checkout_dir {
     system("svn checkout -r $rev $rootdir $dirname")==0 or die "Something went wrong in executing:  svn checkout -r $rev $rootdir $dirname";
   } elsif ( $vc eq "GIT" ) {
     $rev="HEAD" if length($rev)==0;
-    system("git archive --format=tar $rev | ( cd $dirname ; tar -xf -)")==0 or die "Something went wrong in executing:  git archive --format=tar $rev | ( cd $dirname ; tar -xf -)";
+    system("git archive --format=tar $rev | tar -C $dirname -xf -")==0 or die "Something went wrong in executing:  git archive --format=tar $rev | tar -C $dirname -xf -";
   } elsif ( $vc eq "HG" ) {
     system("hg archive --type files -r $rev $dirname")==0 or die "Something went wrong in executing:  hg archive --type files -r $rev $dirname";
   } else {


### PR DESCRIPTION
Fix for #180. The cd/tar line should have no impact on Linux. However I had to change the parsing of $options, I'm unsure about the consequences on Linux.

Windows cmd does not like escaping the options, which causes the invokation of latexdiff in line 490 to fail. Before the change of $options (fails on windows):

    Running: latexdiff  '--flatten' "./latexdiff-vc-0c519c8/thesis.tex" "thesis.tex" > "thesis-diff0c519c8.tex"

After the change of $options (works on windows):

    Running: latexdiff  --flatten "./latexdiff-vc-0c519c8/thesis.tex" "thesis.tex" > "thesis-diff0c519c8.tex"

Let me know what you think @ftilmann 