### PR TITLE
Merge page ranges for minimal diffs

### DIFF
--- a/latexdiff-vc
+++ b/latexdiff-vc
@@ -554,7 +554,7 @@ foreach $diff ( @difffiles ) {
         my $pdftk = `which pdftk`;
         $pdftk =~ s/^\s+|\s+$//g;
         my $command;
-        if (-x $gs && `gs --version` >= 9.20) {
+        if (-x $gs && `$gs --version` >= 9.20) {
           $command="gs -sDEVICE=pdfwrite -dNOPAUSE -dBATCH -dSAFER -sPageList=" . join(",", @pages) . " -sOutputFile=\"$diffbase-changedpage.pdf\" \"$diffbase.pdf\"";
         } elsif (-x $pdftk) {
           $command="pdftk \"$diffbase.pdf\" cat " . join(" ",@pages) . " output \"$diffbase-changedpage.pdf\"";

--- a/latexdiff-vc
+++ b/latexdiff-vc
@@ -608,7 +608,7 @@ sub findchangedpages {
 sub checkout_dir {
   my ($rev,$dirname)=@_;
 
-  unless (-e $dirname) { mkdir $dirname or die "Cannot mkdir $dirname ." ;}
+  unless (-e $dirname) { mkpath([ $dirname ]) or die "Cannot mkdir $dirname ." ;}
   if ( $vc eq "SVN" ) {
     system("svn checkout -r $rev $rootdir $dirname")==0 or die "Something went wrong in executing:  svn checkout -r $rev $rootdir $dirname";
   } elsif ( $vc eq "GIT" ) {

--- a/latexdiff-vc
+++ b/latexdiff-vc
@@ -606,6 +606,8 @@ sub findchangedpages {
 # compresspages(@pages)
 # @pages: sorted array of unique integers (pages)
 # return a list of pages and page ranges. 3 or more consecutive numbers are merged into a "begin-end" string
+#
+# example: join(",", compresspages([1,3,4,5,7,8])) -> join(",", [1,"3-5",7,8]) -> "1,3-5,7,8"
 sub compresspages {
   my (@pages) = @_;
   my @res;

--- a/latexdiff-vc
+++ b/latexdiff-vc
@@ -546,7 +546,7 @@ foreach $diff ( @difffiles ) {
       #print STDERR "Generated postscript file $ps\n";
     } elsif ( $run ) {
       if ( $onlychanges ) {
-	my @pages=findchangedpages("$diffbase.aux");
+	my @pages=compresspages(findchangedpages("$diffbase.aux"));
         my $gs = `which gs`;
         $gs =~ s/^\s+|\s+$//g;
         my $qpdf = `which qpdf`;
@@ -600,6 +600,43 @@ sub findchangedpages {
   close(AUX);
   # sort pages numerically (they should be sorted already; this is just to make sure
   return(sort {$a <=> $b} keys(%pages));
+}
+
+# inspired by a python version posted at https://stackoverflow.com/a/54714846/8136338
+# compresspages(@pages)
+# @pages: sorted array of unique integers (pages)
+# return a list of pages and page ranges. 3 or more consecutive numbers are merged into a "begin-end" string
+sub compresspages {
+  my (@pages) = @_;
+  my @res;
+  my $begin=$pages[0];
+  my $end =$pages[0];
+  my $page;
+  foreach $page ( @pages ) {
+    next if ($page == $begin);
+    if ($page == $end+1) { # handle continuous pages
+      $end = $page;
+      next;
+    } elsif ($begin == $end) { # push single continuous page
+      push @res, $begin;
+      $begin = $end = $page;
+    } elsif ($begin + 1 == $end) { # push two continuous pages
+      push @res, $begin, $end;
+      $begin = $end = $page;
+    } else { # push multiple continuous pages
+      push @res, "$begin-$end";
+      $begin = $end = $page;
+    }
+  }
+  # Finally just check in the same manner for the end element
+  if ($begin == $end) {
+    push @res, $begin;
+  } elsif ($begin + 1 == $end) {
+    push @res, $begin, $end;
+  } else {
+    push @res, "$begin-$end";
+  }
+  return @res;
 }
 
 # checkout_dir(rev,dirname)


### PR DESCRIPTION
When dealing with big documents, at some point the excessive list of pages can exceed the limit supported by gs. All of the tools accept page ranges, so this patch merges 3 or more consecutive pages into a page range.
