### PR TITLE
Support multlined array environment

### DIFF
--- a/latexdiff
+++ b/latexdiff
@@ -280,7 +280,7 @@ my ($ARRENV,
 # my $MATHREPL='displaymath';  # Environment introducing deleted maths blocks
 # my $MATHARRENV='(?:eqnarray|align|alignat|gather|multline|flalign)[*]?' ;           # Environments turning on eqnarray math mode
 # my $MATHARRREPL='eqnarray*';  # Environment introducing deleted maths blocks
-# my $ARRENV='(?:aligned|gathered|array|[pbvBV]?matrix|smallmatrix|cases|split)'; # Environments making arrays in math mode.  The underlining style does not cope well with those - as a result in-text math environments are surrounded by \mbox{ } if any of these commands is used in an inline math block
+# my $ARRENV='(?:aligned|gathered|multlined|array|[pbvBV]?matrix|smallmatrix|cases|split)'; # Environments making arrays in math mode.  The underlining style does not cope well with those - as a result in-text math environments are surrounded by \mbox{ } if any of these commands is used in an inline math block
 # my $COUNTERCMD='(?:footnote|part|chapter|section|subsection|subsubsection|paragraph|subparagraph)';  # textcmds which are associated with a counter
 #                                         # If any of these commands occur in a deleted block
 #                                         # they will be succeeded by an \addtocounter{...}{-1}
@@ -5158,6 +5158,7 @@ flalign[*]?
 %%BEGIN ARRENV CONFIG
 aligned
 gathered
+multlined
 array
 [pbvBV]?matrix
 smallmatrix


### PR DESCRIPTION
This simply adds `multlined` (from the `amsmath` package) to the list of math array environments.
Note that I don't actually know Perl, I just copied #116 and it seems to work. 