### PR TITLE
sanitize more possible input schemata of frac

### DIFF
--- a/latexdiff
+++ b/latexdiff
@@ -2570,16 +2570,15 @@ sub take_comments_and_newline_from_frac() {
   # some special magic for common usage of frac, which does not conform to the latexdiff requirements but can be made to fit
   # note that this is a rare exception to the general rule that the new tex can be reconstructed from the diff file
 
+  # regex that matches space and comment characters
+  my $space = qr/\s|%[^\n]*?/;
+  # \frac {abc} -> \frac{abc}
   # \frac1 -> \frac{1}
   # \frac a -> \frac{a}
   # \frac \lambda -> \frac{\lambda}
-  s/\\frac(?:\s*(\d)|\s+(\w)|\s*(\\[a-zA-Z]+))/\\frac\{$1$2$3\}/g;
+  s/\\frac(?:${space}+\{($pat_n)\}|${space}*(\d)|${space}+(\w)|${space}*(\\[a-zA-Z]+))/\\frac\{$1$2$3$4\}/g;
   # same as above for the second argument of frac
-  s/\\frac(\{$pat_n\})(?:\s*(\d)|\s+(\w)|\s*(\\[a-zA-Z]+))/\\frac$1\{$2$3$4\}/g;
-
-  # delete space and comment characters between \frac arguments
-#  s/\\frac(?:\s*?%[^\n]*?)*?(\{$pat_n\})\s*(\{$pat_n\})/\\frac$1$2/g;
-  s/\\frac(?:\s|%[^\n]*?)*(\{$pat_n\})(?:\s|%[^\n]*?)*(\{$pat_n\})/\\frac$1$2/g;
+  s/\\frac(\{$pat_n\})(?:${space}*\{($pat_n)\}|${space}*(\d)|${space}+(\w)|${space}*(\\[a-zA-Z]+))/\\frac$1\{$2$3$4$5\}/g;
 }
 
 # preprocess($string, ..)

--- a/latexdiff
+++ b/latexdiff
@@ -2570,11 +2570,12 @@ sub take_comments_and_newline_from_frac() {
   # some special magic for common usage of frac, which does not conform to the latexdiff requirements but can be made to fit
   # note that this is a rare exception to the general rule that the new tex can be reconstructed from the diff file
 
-  # \frac12 -> \frac{1}{2}
-  s/\\frac(\d)(\w)/\\frac\{$1\}\{$2\}/g;
-
-  # \frac1{2b} -> \frac{1}{2b}
-  s/\\frac(\d)/\\frac\{$1\}/g;
+  # \frac1 -> \frac{1}
+  # \frac a -> \frac{a}
+  # \frac \lambda -> \frac{\lambda}
+  s/\\frac(?:\s*(\d)|\s+(\w)|\s*(\\[a-zA-Z]+))/\\frac\{$1$2$3\}/g;
+  # same as above for the second argument of frac
+  s/\\frac(\{$pat_n\})(?:\s*(\d)|\s+(\w)|\s*(\\[a-zA-Z]+))/\\frac$1\{$2$3$4\}/g;
 
   # delete space and comment characters between \frac arguments
 #  s/\\frac(?:\s*?%[^\n]*?)*?(\{$pat_n\})\s*(\{$pat_n\})/\\frac$1$2/g;

--- a/latexdiff
+++ b/latexdiff
@@ -2576,9 +2576,9 @@ sub take_comments_and_newline_from_frac() {
   # \frac1 -> \frac{1}
   # \frac a -> \frac{a}
   # \frac \lambda -> \frac{\lambda}
-  s/\\frac(?:${space}+\{($pat_n)\}|${space}*(\d)|${space}+(\w)|${space}*(\\[a-zA-Z]+))/\\frac\{$1$2$3$4\}/g;
+  s/\\frac(?|${space}+\{($pat_n)\}|${space}*(\d)|${space}+(\w)|${space}*(\\[a-zA-Z]+))/\\frac\{$1\}/g;
   # same as above for the second argument of frac
-  s/\\frac(\{$pat_n\})(?:${space}*\{($pat_n)\}|${space}*(\d)|${space}+(\w)|${space}*(\\[a-zA-Z]+))/\\frac$1\{$2$3$4$5\}/g;
+  s/\\frac(\{$pat_n\})(?|${space}*\{($pat_n)\}|${space}*(\d)|${space}+(\w)|${space}*(\\[a-zA-Z]+))/\\frac$1\{$2\}/g;
 }
 
 # preprocess($string, ..)


### PR DESCRIPTION
This is not polished yet.

It sanitizes the cases in https://github.com/ftilmann/latexdiff/issues/50 and more, such as
```
\documentclass{article}
\begin{document}
\begin{equation}
x = \frac \lambda b
\end{equation}
\begin{equation}
x = \frac12
\end{equation}
\end{document}
```
with spaces added and removed at will.

It still gives warnings because it tries to print capture group variables which haven't captured anything. It also does not deal with newlines or comment symbols yet. I am not sure what is the best way to fix either of these issues.