### PR TITLE
Fixed a bug that prevented finding nested subfiles

### DIFF
--- a/latexdiff
+++ b/latexdiff
@@ -1792,7 +1792,7 @@ sub flatten {
 	     ($subpreamble,$subbody,$subpost)=splitdoc($subfile,'\\\\begin\{document\}','\\\\end\{document\}');
 	     ###           $subfile=~s|^.*\\begin{document}||s; 
 	     ###           $subfile=~s|\\end{document}.*$||s;
-	     $replacement=flatten($subbody, $preamble,$filename,$encoding);
+	     $replacement=flatten($subbody, $preamble,$fullfile,$encoding);
 	     ### $replacement = remove_endinput($replacement); 
 	   } else {
 	      # if file does not exist, do not expand subfile


### PR DESCRIPTION
When we use the package `\subfiles` and if we load nested files with relative paths, e.g., if we have more `\subfiles` in a file read by `\subfile`, which is in some different directory, `latexdiff` cannot deal with the inner `\subfile`.

This is due to the fact that when expanding the `\subfile`, the argument to flatten is `$filename`, i.e. the current path.
https://github.com/ftilmann/latexdiff/blob/9d3a00aec26984018fdca1086ddff97af9678541/latexdiff#L1795
By changing `$filename` to `$fullfile`, i.e., the path of the file to read, the program can find the file even when there is nesting.