### PR TITLE
Generalize regex in latexdiff-vc > findchangedpages

### DIFF
--- a/latexdiff-vc
+++ b/latexdiff-vc
@@ -600,10 +600,10 @@ sub findchangedpages {
   my %start;
   open(AUX,$auxfile) or die ("Could open aux file $auxfile . System error: $!");
   while (<AUX>) {
-    if (m/\\zref\@newlabel\{DIFchgb(\d*)\}\{.*\\abspage\{(\d*)\}\}/ ) { 
+    if (m/\\zref\@newlabel\{DIFchgb(\d*)\}\{.*\\abspage\{(\d*)\}.*\}/ ) { 
       $start{$1}=$2; $pages{$2}=1;
     }
-    if (m/\\zref\@newlabel\{DIFchge(\d*)\}\{.*\\abspage\{(\d*)\}\}/) { 
+    if (m/\\zref\@newlabel\{DIFchge(\d*)\}\{.*\\abspage\{(\d*)\}.*\}/) { 
       if (defined($start{$1})) {
 	for ($j=$start{$1}; $j<=$2; $j++) {
 	  $pages{$j}=1;


### PR DESCRIPTION
Depending on the packages used, latexdiff-vc with option --only-changed is unable to parse changed pages, the reason being that \abspage{} might not be in last position.