### PR TITLE
Makefile: fix example-diff.tex target, depend on and use diff/latexdiff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,8 @@ latexdiff-vc.tex: latexdiff-vc
 example-diff.pdf: example-diff.tex
 	pdflatex example-diff.tex
 
-example-diff.tex: example-draft.tex example-rev.tex latexdiff
-	latexdiff -t UNDERLINE example-draft.tex example-rev.tex > example-diff.tex
+example-diff.tex: example-draft.tex example-rev.tex dist/latexdiff
+	./dist/latexdiff -t UNDERLINE example-draft.tex example-rev.tex > example-diff.tex
 
 dist/example/example-draft.tex: example-draft.tex
 	cp $< $@


### PR DESCRIPTION
Use ./dist/latexdiff instead of latexdiff in path for the Makefile target. This helps especially in "bootstrap" scenarios, for example, https://bugs.gentoo.org/947303.