### PR TITLE
README.md: fix link to git-latexdiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ LATEXDIFFCITE (Author: Christer van der Meeren)  is a wrapper around latexdiff t
 https://github.com/twilsonco/latexdiffcite
 
 GIT-LATEXDIFF (lead author: Matthieu Moy) is a wrapper (bash script) around latexdiff that allows using it to diff two revisions of a LaTeX file under git revision control (similar functionality is provided by latexdiff-vc --git with --flatten option included with this distribution but git-latexdiff allows more fine-grained control on (not to be confused with latexdiff-git, which is normally installed as a soft link to latexdiff-vc) 
-https://gitorious.org/git-latexdiff/
+https://gitlab.com/git-latexdiff/git-latexdiff
 
 WISHING TO CONTRIBUTE
 ---------------------


### PR DESCRIPTION
The previous link was dead.